### PR TITLE
Add no-warning-comments rule

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -20,6 +20,7 @@
     "max-params": ["error", 4],
     "max-depth": ["error", 5],
     "max-len": ["error", 120, 2],
-    "max-lines": ["error", 500]
+    "max-lines": ["error", 500],
+    "no-warning-comments": ["warn", {"terms": ["todo", "fixme"], "location": "start"}]
   }
 }


### PR DESCRIPTION
@kern: not totally sure how to test this without screwing up a dev environment; something to chat about tomorrow? Hopefully as simple as including it in a project.

This should warn when `TODO` or `FIXME` appear in project code, which is a useful tool for approving code post-review.

Rule documented here: http://eslint.org/docs/rules/no-warning-comments

Issue here: https://github.com/usepavlov/issues/issues/67
